### PR TITLE
feature(model): Add model parsing in CLI to support different models

### DIFF
--- a/src/article/article.rs
+++ b/src/article/article.rs
@@ -1,3 +1,4 @@
+#[allow(unused_imports)]
 use clap::{Parser, Subcommand};
 use kalosm::language::*;
 use serde::Deserialize;
@@ -21,7 +22,6 @@ impl ToString for ArticleType {
 
 #[derive(Parse, Clone, Debug, Schema, Deserialize)]
 pub struct Article {
-
     #[parse(pattern = r"[a-zA-Z,.?!\d ]+")]
     pub reasoning: String,
 

--- a/src/article/mod.rs
+++ b/src/article/mod.rs
@@ -1,6 +1,5 @@
 mod article;
-pub use article::{Article, ArticleType};
+pub use article::Article;
 
 mod examples;
 pub use examples::{EXAMPLE_INPUT, EXAMPLE_OUTPUT};
-

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -1,6 +1,6 @@
 use std::fs;
-use std::path::PathBuf;
 use std::io::{self, Read};
+use std::path::PathBuf;
 
 pub fn load_file_content(input_path: &PathBuf) -> Result<String, io::Error> {
     // Open the file and read the content into a String
@@ -27,4 +27,3 @@ mod tests {
         assert_eq!(content.trim(), "Test content");
     }
 }
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,9 @@ use loader::load_file_content;
 mod article;
 use article::{Article, EXAMPLE_INPUT, EXAMPLE_OUTPUT};
 
+mod models;
+use models::Model;
+
 use clap::{Parser, Subcommand};
 use indicatif::{ProgressBar, ProgressStyle};
 use kalosm::language::*;
@@ -25,7 +28,7 @@ enum Commands {
         #[arg(short, long, value_name = "INPUT_FOLDER")]
         input_folder: PathBuf,
         #[arg(short, long, value_name = "MODEL")]
-        model: String,
+        model: Model,
     },
     Mesure,
 }
@@ -57,15 +60,17 @@ async fn main() {
                 }
             };
 
-            pb.set_message("Building LLM model...");
+            pb.finish_with_message("Building LLM model...");
             // Then set up a task with a prompt and constraints
+
             let llm = Llama::builder()
-                .with_source(LlamaSource::phi_3_mini_4k_instruct())
+                .with_source(model.get_llama_source())
                 .build()
                 .await
                 .unwrap();
 
             pb.set_message("Creating task...");
+
             let task = llm
                 .task("You are a Jurist. Please extract the article number, date, and content of the legal text.")
                 .with_example(EXAMPLE_INPUT, EXAMPLE_OUTPUT)

--- a/src/models/available.rs
+++ b/src/models/available.rs
@@ -1,0 +1,43 @@
+use clap::ValueEnum;
+use kalosm::language::LlamaSource;
+use std::fmt;
+
+#[derive(Debug, Clone, ValueEnum)]
+pub enum Model {
+    Llama323bChat,
+    Phi35Mini4kInstruct,
+    Phi3Mini4kInstruct,
+    Phi4,
+    Qwen2515bInstruct,
+    Qwen253bInstruct,
+    TinyLlama11bChat,
+}
+
+impl fmt::Display for Model {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let model_name = match self {
+            Model::Llama323bChat => "Llama-3.2-3B-chat",
+            Model::Phi35Mini4kInstruct => "Phi-3.5-mini-4k-instruct",
+            Model::Phi3Mini4kInstruct => "Phi-3-mini-4k-instruct",
+            Model::Phi4 => "phi-4",
+            Model::Qwen2515bInstruct => "Qwen2.5-1.5B-instruct",
+            Model::Qwen253bInstruct => "Qwen2.5-3B-instruct",
+            Model::TinyLlama11bChat => "Tiny-Llama-1.1b-chat",
+        };
+        write!(f, "{}", model_name)
+    }
+}
+
+impl Model {
+    pub fn get_llama_source(&self) -> LlamaSource {
+        match self {
+            Model::Llama323bChat => LlamaSource::llama_3_2_3b_chat(),
+            Model::Phi35Mini4kInstruct => LlamaSource::phi_3_5_mini_4k_instruct(),
+            Model::Phi3Mini4kInstruct => LlamaSource::phi_3_mini_4k_instruct(),
+            Model::Phi4 => LlamaSource::phi_4(),
+            Model::Qwen2515bInstruct => LlamaSource::qwen_2_5_1_5b_instruct(),
+            Model::Qwen253bInstruct => LlamaSource::qwen_2_5_3b_instruct(),
+            Model::TinyLlama11bChat => LlamaSource::tiny_llama_1_1b_chat(),
+        }
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,0 +1,2 @@
+mod available;
+pub use available::Model;


### PR DESCRIPTION
Support for:
- llama 3.2 models
- tiny_llama (Old llama 1 model from TheBloke)
- Qwen 2.5 models
- Phi 3.5 tiny versions
- Phi 4